### PR TITLE
support for literal versions and matchers

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,3 +1,7 @@
 version = "2.7.5"
 maxColumn = 100
 align.preset = more
+project.includeFilters = [
+  "lib",
+  "cli"
+]

--- a/build.sbt
+++ b/build.sbt
@@ -17,6 +17,9 @@ ThisBuild / developers := List(
   )
 )
 
+//a subproject "semver4s" gets automatically created
+//and aggregates all subprojects.
+//I don't think you can disable that project, only rename it
 //lazy val global = project
 //  .in(file("."))
 //  .aggregate(lib, cli)
@@ -35,6 +38,10 @@ lazy val lib = projectMatrix
       "org.scalameta" %% "munit"            % "0.7.21",
       "org.scalameta" %% "munit-scalacheck" % "0.7.21"
     ),
+    libraryDependencies ++= List(
+      "org.scala-lang" % "scala-reflect" % scalaVersion.value % "provided"
+    )
+      .filter(_ => scalaVersion.value.startsWith("2")),
     publishTo := sonatypePublishToBundle.value,
     sonatypeProjectHosting := Some(
       GitHubHosting("martijnhoekstra", "semver4s", "martijnhoekstra@gmail.com")

--- a/cli/src/main/scala/semver4s/cli/SemverApp.scala
+++ b/cli/src/main/scala/semver4s/cli/SemverApp.scala
@@ -87,7 +87,7 @@ object SemverApp
 
 abstract class ParserArgument[A](p: Parser0[A]) extends Argument[A] {
   def read(input: String) = {
-    def reporter = new Reporter(input)
+    def reporter = new parsing.Reporter(input)
     p.parseAll(input).left.map(reporter.report).toValidated
   }
 }

--- a/semver4s/src/main/scala-2/semver4s/Literal.scala
+++ b/semver4s/src/main/scala-2/semver4s/Literal.scala
@@ -1,0 +1,84 @@
+package semver4s
+
+import scala.reflect.macros.blackbox.Context
+
+object Literal {
+
+  def version(s: String): Version = macro versionImpl
+  def matcher(s: String): Matcher = macro matcherImpl
+
+  def versionImpl(c: Context)(s: c.Expr[String]) = versionFromTree(c)(s.tree)
+  def matcherImpl(c: Context)(s: c.Expr[String]) = matcherFromTree(c)(s.tree)
+
+  def versionFromTree(c: Context)(t: c.Tree) = {
+    import c.{universe => u}
+    import u._
+    t match {
+      case u.Literal(u.Constant(s: String)) =>
+        def r = new parsing.Reporter(s)
+        semver4s
+          .version(s)
+          .fold(
+            e => c.abort(c.enclosingPosition, r.report(e).toList.mkString),
+            _ => q"_root_.semver4s.parsing.SemverParser.semver.parseAll($s).toOption.get"
+          )
+      case _ =>
+        c.abort(
+          c.enclosingPosition,
+          s"This method uses a macro to verify that a String literal is a valid version. semver4s.version if you have a dynamic String that you want to parse."
+        )
+    }
+  }
+
+  def matcherFromTree(c: Context)(t: c.Tree) = {
+    import c.{universe => u}
+    import u._
+    t match {
+      case u.Literal(u.Constant(s: String)) =>
+        def r = new parsing.Reporter(s)
+        semver4s
+          .matcher(s)
+          .fold(
+            e => c.abort(c.enclosingPosition, r.report(e).toList.mkString),
+            _ => q"_root_.semver4s.parsing.MatcherParser.rangeSet.parseAll($s).toOption.get"
+          )
+      case _ =>
+        c.abort(
+          c.enclosingPosition,
+          s"This method uses a macro to verify that a String literal is a valid matcher. use semver4s.matcher if you have a dynamic String that you want to parse."
+        )
+    }
+  }
+
+  implicit class Extensions(val ctx: StringContext) extends AnyVal {
+    def m(args: Any*): Matcher = macro mImpl
+    def v(args: Any*): Version = macro vImpl
+  }
+
+  def mImpl(c: Context)(args: c.Expr[Any]*): c.universe.Tree = {
+    import c.universe._
+    c.prefix.tree match {
+      case Apply(_, List(Apply(_, List(single)))) =>
+        matcherFromTree(c)(single)
+      case _ =>
+        c.abort(
+          c.enclosingPosition,
+          s"matcher interpolators can't have any values interpolated, but $args found"
+        )
+    }
+  }
+
+  def vImpl(c: Context)(args: c.Expr[Any]*): c.universe.Tree = {
+    import c.universe._
+    c.prefix.tree match {
+      case Apply(_, List(Apply(_, List(single)))) =>
+        versionFromTree(c)(single)
+      case _ =>
+        c.abort(
+          c.enclosingPosition,
+          s"version interpolators can't have any values interpolated, but $args found"
+        )
+    }
+  }
+
+}

--- a/semver4s/src/main/scala-3/semver4s/Literal.scala
+++ b/semver4s/src/main/scala-3/semver4s/Literal.scala
@@ -1,0 +1,94 @@
+package semver4s
+
+import scala.quoted._
+import cats.data.NonEmptyList
+
+object Literal:
+  inline def version(inline s: String) = ${versionImpl('{s})}
+  inline def matcher(inline s: String) = ${matcherImpl('{s})}
+
+  extension (inline sc: StringContext)
+    inline def v(inline args: Any*) = ${interpolatedVersionImpl('{sc})}
+    inline def m(inline args: Any*) = ${interpolatedMatcherImpl('{sc})}
+
+  private def unliftLiteral[A: FromExpr, B: ToExpr](a: Expr[A], f: A => Option[B])(using Quotes): Expr[B] =
+    Expr(f(a.valueOrError).getOrElse {
+      quotes.reflect.report.error("value not in unlifted domain of f")
+      ???
+    })
+
+  given ToExpr[Version] with
+    def apply(x: Version)(using Quotes): Expr[Version] = x match {
+      case Version(maj, min, pat, pre, bld) =>
+        '{Version(${Expr(maj)}, ${Expr(min)}, ${Expr(pat)}, ${Expr(pre)}, ${Expr(bld)})}
+    }
+
+  given ToExpr[Matcher.Simple] with
+    import Matcher._
+    def apply(m: Simple)(using Quotes): Expr[Simple] = m match {
+      case Hyphen(below, above) => '{Hyphen(${Expr(below)}, ${Expr(above)})}
+      case Caret(p) => '{Caret(${Expr(p)})}
+      case Tilde(p) => '{Tilde(${Expr(p)})}
+      case Exact(p) =>'{Exact(${Expr(p)})}
+      case GT(p) => '{GT(${Expr(p)})}
+      case GTE(p) => '{GTE(${Expr(p)})}
+      case LT(p) => '{LT(${Expr(p)})}
+      case LTE(p) => '{LTE(${Expr(p)})}
+    }
+
+  given ToExpr[Matcher.And] with
+    import Matcher._
+    def apply(m: And)(using Quotes): Expr[And] = '{And(${Expr(m.simples)})}
+
+  given ToExpr[Matcher.Or] with
+    import Matcher._
+    def apply(m: Or)(using Quotes): Expr[Or] = '{Or(${Expr(m.ands)})}
+
+  given ToExpr[Matcher] with
+    import Matcher._
+    def apply(m: Matcher)(using Quotes): Expr[Matcher] = m match {
+      case s: Simple => Expr(s)
+      case o: Or => Expr(o)
+      case a: And => Expr(a)
+    }
+
+
+  given ToExpr[Partial] with
+    import Partial._
+    def apply(x: Partial)(using Quotes): Expr[Partial] = x match {
+      case Wild => '{Partial.Wild}
+      case Major(m) => '{Partial.Major(${Expr(m)})}
+      case Minor(maj, min) => '{Partial.Minor(${Expr(maj)}, ${Expr(min)})}
+      case Patch(maj, min, pat) => '{Partial.Patch(${Expr(maj)}, ${Expr(min)}, ${Expr(pat)})}
+      case Pre(maj, min, pat, pre) => '{Partial.Pre(${Expr(maj)}, ${Expr(min)}, ${Expr(pat)}, ${Expr(pre)})}
+    }
+
+  given [T: ToExpr : Type]: ToExpr[NonEmptyList[T]] with
+    def apply(xs: NonEmptyList[T])(using Quotes) =
+      '{NonEmptyList(${Expr(xs.head)}, ${Expr(xs.tail)})}
+
+  private def versionImpl(expr: Expr[String])(using Quotes): Expr[Version] =
+    unliftLiteral(expr, a => parsing.SemverParser.semver.parseAll(a).toOption)
+
+  private def matcherImpl(expr: Expr[String])(using Quotes): Expr[Matcher] =
+    unliftLiteral(expr, a => parsing.MatcherParser.matcher.parseAll(a).toOption)
+
+  private def interpolatedVersionImpl(esc: Expr[StringContext])(using Quotes) = {
+    val sc = esc.valueOrError
+    sc.parts match
+      case List(single: String) => versionImpl(Expr(single))
+      case _ => {
+        quotes.reflect.report.error("version interpolator allows only single string")
+        ???
+      }
+  }
+
+  private def interpolatedMatcherImpl(esc: Expr[StringContext])(using Quotes) = {
+    val sc = esc.valueOrError
+    sc.parts match
+      case List(single: String) => matcherImpl(Expr(single))
+      case _ => {
+        quotes.reflect.report.error("matcher interpolator allows only single string")
+        ???
+      }
+  }

--- a/semver4s/src/main/scala/semver4s/parsing/MatcherParser.scala
+++ b/semver4s/src/main/scala/semver4s/parsing/MatcherParser.scala
@@ -29,10 +29,9 @@ object MatcherParser {
     object EQ  extends SimpleOp
   }
 
-  val star = P.charIn("xX*")
-
   val partial: P[Partial] = {
-    val s = star.as(Nil -> None)
+    val star = P.charIn("xX*")
+    val s    = star.as(Nil -> None)
 
     val patch = (long ~ preRelease.?)
     val minor = long ~ {
@@ -89,6 +88,8 @@ object MatcherParser {
 
   val logicalOr = P.string("||").surroundedBy(P.char(' ').rep)
   val rangeSet  = range.repSep(logicalOr).map(Or(_))
+
+  val matcher: P[Matcher] = rangeSet
 
   def hyphenRange(lower: Partial, upper: Partial) = Hyphen(lower, upper)
 

--- a/semver4s/src/main/scala/semver4s/parsing/Reporter.scala
+++ b/semver4s/src/main/scala/semver4s/parsing/Reporter.scala
@@ -1,4 +1,4 @@
-package semver4s
+package semver4s.parsing
 
 import cats.parse.Parser
 import cats.data.NonEmptyList

--- a/semver4s/src/test/scala/MacrosTest.scala
+++ b/semver4s/src/test/scala/MacrosTest.scala
@@ -1,0 +1,15 @@
+package semver4s
+
+class MacrosTest extends munit.ScalaCheckSuite {
+  import Literal._
+  test("version interpolator") {
+    assertEquals(Version(1, 2, 3), v"1.2.3")
+  }
+
+  test("matcher interpolator") {
+    val matcher = m">1 || ~0.3.1"
+    assert(matcher.matches(v"2.0.0"))
+    assert(matcher.matches(v"0.3.2"))
+
+  }
+}


### PR DESCRIPTION
`
Literal.m"~1.2.3".matches(Literal.v"1.2.5")
`