### PR TITLE
allow < loose to match smaller core-versions

### DIFF
--- a/semver4s/src/main/scala/semver4s/Matcher.scala
+++ b/semver4s/src/main/scala/semver4s/Matcher.scala
@@ -188,7 +188,9 @@ object Matcher {
         p match {
           case Wild => true
           case Pre(major, minor, patch, pre) =>
-            CoreVersion(major, minor, patch) == that.coreVersion && that.pre < Option(pre)
+            CoreVersion(major, minor, patch).get == that.coreVersion && that.pre < Option(pre) ||
+              (that.coreVersion.toVersion < CoreVersion(major, minor, patch).get.toVersion) &&
+              preBehaviour == Loose
           case _ if preBehaviour == Strict =>
             false
           case Major(major) =>

--- a/semver4s/src/test/scala/GenVersion.scala
+++ b/semver4s/src/test/scala/GenVersion.scala
@@ -42,9 +42,9 @@ object GenVersion {
         d    <- deviations
       } yield {
         val rough = base + d
-          if (rough > max) base - math.abs(d)
-          else if (rough < max) base + math.abs(d)
-          else rough
+        if (rough > max) base - math.abs(d)
+        else if (rough < max) base + math.abs(d)
+        else rough
       }
       rough1.retryUntil(i => i >= min && i <= max)
     }
@@ -63,9 +63,9 @@ object GenVersion {
         d    <- deviations
       } yield {
         val rough = base + d
-          if (rough > max) base - math.abs(d)
-          else if (rough < max) base + math.abs(d)
-          else rough
+        if (rough > max) base - math.abs(d)
+        else if (rough < max) base + math.abs(d)
+        else rough
       }
       rough1.retryUntil(i => i >= min && i <= max)
     }

--- a/semver4s/src/test/scala/MatcherTest.scala
+++ b/semver4s/src/test/scala/MatcherTest.scala
@@ -202,6 +202,31 @@ class MatcherTest extends munit.ScalaCheckSuite {
       .reduce(_ && _)
   }
 
+  test("loose eq") {
+    val version = v"1.4.0-1"
+    val m1      = m"1.2.3 - 2.3.*"
+    val m2      = m">=1.2.3 <2.4.0-0"
+    val mm1     = m1.matches(version, PreReleaseBehaviour.Loose)
+    val mm2     = m2.matches(version, PreReleaseBehaviour.Loose)
+    assert(m">=1.2.3".matches(version, PreReleaseBehaviour.Loose))
+    assert(m"<2.4.0-0".matches(version, PreReleaseBehaviour.Loose))
+    assert(mm2, "decomposed range should match loosely")
+    assert(mm1, "hyphen range should not match loosely")
+  }
+
+  test("loose lte") {
+    val version = v"1.4.0-1"
+    val m1      = m"<=2.3.*"
+    assert(m1.matches(version, PreReleaseBehaviour.Loose))
+  }
+
+  test("loose lt") {
+    val m1  = m"<2.4.0-0"
+    val ver = v"1.4.0-1"
+    assert(m1.matches(ver, PreReleaseBehaviour.Loose))
+    assert(!m1.matches(ver, PreReleaseBehaviour.Strict))
+  }
+
   //If a partial version is provided as the second version in the inclusive range, then all versions that start with the supplied parts of the tuple are accepted, but nothing that would be greater than the provided tuple parts.
   //1.2.3 - 2.3 -> >=1.2.3 <2.4.0-0
   //1.2.3 - 2 := >=1.2.3 <3.0.0-0


### PR DESCRIPTION
lt matchers with pre-release should be able to match smaller core versions when matching in loose mode.